### PR TITLE
Add dependency installation for Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
         os: [ macos-14, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: install dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install -y libc6-dev-i386
       - name: print architecture
         run: uname -m
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update the test workflow to install `libc6-dev-i386` on `ubuntu-latest` only. This ensures that necessary dependencies are available for the Ubuntu environment during CI. No changes were made for macOS or Windows.